### PR TITLE
feat: added casdoor_authentication_url (endpoint) customization option

### DIFF
--- a/casdoor_oauth/data/casdoor_oauth_data.xml
+++ b/casdoor_oauth/data/casdoor_oauth_data.xml
@@ -2,10 +2,8 @@
 <odoo>
     <data>
         <record id="provider_casdoor" model="auth.oauth.provider">
-            <field name="name">Casdoor</field>
-            <field name="auth_endpoint">http://test.casbin.com:8000/login/oauth/authorize</field>
-            <field name="scope">read</field>
-            <field name="validation_endpoint">http://test.casbin.com:8000/api/get-user</field>
+            <field name="name">Casdoor</field>            
+            <field name="scope">read</field>            
             <field name="data_endpoint"></field>
             <field name="css_class">fa fa-fw fa-key</field>
             <field name="body">Log in with Casdoor</field>

--- a/casdoor_oauth/models/res_config_settings.py
+++ b/casdoor_oauth/models/res_config_settings.py
@@ -11,6 +11,7 @@ class ResConfigSettings(models.TransientModel):
     auth_oauth_casdoor_enabled = fields.Boolean(string='Active')
     auth_oauth_casdoor_client_id = fields.Char(string='Casdoor Client ID')  # Our identifier
     auth_oauth_casdoor_client_secret = fields.Char(string='Casdoor Client Secret')
+    auth_oauth_casdoor_authentication_url = fields.Char(string='Casdoor Authentication URL')
 
     @api.model
     def get_values(self):
@@ -19,7 +20,8 @@ class ResConfigSettings(models.TransientModel):
         casdoor_provider and res.update(
             auth_oauth_casdoor_enabled=casdoor_provider.enabled,
             auth_oauth_casdoor_client_id=casdoor_provider.client_id,
-            auth_oauth_casdoor_client_secret=casdoor_provider.client_secret,            
+            auth_oauth_casdoor_client_secret=casdoor_provider.client_secret,
+            auth_oauth_casdoor_authentication_url = casdoor_provider.auth_endpoint,
         )
         return res
 
@@ -29,5 +31,6 @@ class ResConfigSettings(models.TransientModel):
         casdoor_provider and casdoor_provider.write({
             'enabled': self.auth_oauth_casdoor_enabled,
             'client_id': self.auth_oauth_casdoor_client_id,
-            'client_secret': self.auth_oauth_casdoor_client_secret,            
+            'client_secret': self.auth_oauth_casdoor_client_secret,
+            'auth_endpoint': self.auth_oauth_casdoor_authentication_url,
         })

--- a/casdoor_oauth/models/res_users.py
+++ b/casdoor_oauth/models/res_users.py
@@ -22,8 +22,6 @@ class ResUsers(models.Model):
             casdoor_key = "CasdoorSecret"
             algorithms = "HS256"
             return_json = jwt.decode(access_token, casdoor_key, algorithms=algorithms, audience=oauth_provider.client_id)
-            if return_json is None:
-                raise ValueError("The request params do not comply with Casdoor's database.")
             return return_json            
         else:
             return super()._auth_oauth_rpc(endpoint, access_token)

--- a/casdoor_oauth/views/res_config_settings_views.xml
+++ b/casdoor_oauth/views/res_config_settings_views.xml
@@ -15,6 +15,7 @@
                             <div class="col-12 col-lg-6 o_setting_box" id="casdoor_oauth_settings">
 
                                 <group>
+                                    <field name="auth_oauth_casdoor_authentication_url"/>
                                     <field name="auth_oauth_casdoor_client_id"/>
                                     <field name="auth_oauth_casdoor_client_secret"/>
                                     <field name="auth_oauth_casdoor_enabled"/>


### PR DESCRIPTION
Now enterprise users can setup and specify their own Casdoor instance server URL. 
Before this PR they can only use [test.casbin.com:8000](http://test.casbin.com:8000/) as the hard-coded test URL.

Signed-off-by: ffyuanda <shaoxuan.yuan02@gmail.com>